### PR TITLE
Ignore H slot in FAA logic

### DIFF
--- a/src/main/java/com/github/lstephen/ootp/ai/value/FreeAgentAcquisition.java
+++ b/src/main/java/com/github/lstephen/ootp/ai/value/FreeAgentAcquisition.java
@@ -66,7 +66,7 @@ public final class FreeAgentAcquisition {
 
         // Penalize for releasing player in needed slot
         for (Slot s : release.getSlots()) {
-            if (s != Slot.P) {
+            if (s != Slot.P && s != Slot.H) {
                 score -= Math.max(0, rr.getTargetRatio() - rr.getRatio(s));
             }
         }


### PR DESCRIPTION
H's will always be required as it's rare to have H exclusive players
now. As such keeping plays because they contribute as a H is
overweighted. Once Slots are removed this will be tweaked considerably.